### PR TITLE
initial pass at windows icons

### DIFF
--- a/electron/main/ipc/app.ts
+++ b/electron/main/ipc/app.ts
@@ -8,8 +8,10 @@ export const appIpc = createIpcHandlers({
   },
 
   '/app/getFolderImage': async () => {
+    const path = process.platform === 'win32' ? 'C:\\Windows' : '/';
+
     return (
-      await nativeImage.createThumbnailFromPath('/', {
+      await nativeImage.createThumbnailFromPath(path, {
         height: 32,
         width: 32,
       })
@@ -17,11 +19,23 @@ export const appIpc = createIpcHandlers({
   },
 
   '/app/getBucketImage': async () => {
+    if (process.platform === 'darwin') {
+      return (
+        await nativeImage.createThumbnailFromPath(
+          '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericFileServerIcon.icns',
+          {
+            height: 32,
+            width: 32,
+          },
+        )
+      ).toDataURL();
+    }
+
     return (
-      await nativeImage.createThumbnailFromPath(
-        '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericFileServerIcon.icns',
-        { height: 32, width: 32 },
-      )
+      await nativeImage.createThumbnailFromPath('C:\\Windows', {
+        height: 32,
+        width: 32,
+      })
     ).toDataURL();
   },
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue';
 import {
   useConnectionsStore,
   useLayoutStore,
@@ -15,22 +16,24 @@ import Main from '@/views/Main.vue';
 import Dialog from '@/components/dialog/Dialog.vue';
 import { serialize } from './utils';
 
-// For now just force dark mode
-document.documentElement.classList.add('dark');
+onMounted(async () => {
+  // For now just force dark mode
+  document.documentElement.classList.add('dark');
 
-const connectionsStore = useConnectionsStore();
-const layoutStore = useLayoutStore();
-const transfersStore = useTransfersStore();
+  const connectionsStore = useConnectionsStore();
+  const layoutStore = useLayoutStore();
+  const transfersStore = useTransfersStore();
 
-connectionsStore.getConnections();
-layoutStore.getStandardIcons();
-layoutStore.getOs();
-transfersStore.registerTransferEvents();
+  transfersStore.registerTransferEvents();
+  connectionsStore.getConnections();
+  layoutStore.getOs();
+  layoutStore.getStandardIcons();
 
-window.serialize = serialize;
+  window.serialize = serialize;
 
-window.onWindowState((state) => {
-  layoutStore.windowState = state;
+  window.onWindowState((state) => {
+    layoutStore.windowState = state;
+  });
 });
 </script>
 

--- a/src/stores/layout.ts
+++ b/src/stores/layout.ts
@@ -84,15 +84,23 @@ export const useLayoutStore = defineStore('layout', {
     },
 
     async getStandardIcons() {
-      const res = await Promise.all([
-        ipcInvoke('/app/getBucketImage'),
-        ipcInvoke('/app/getFolderImage'),
-        ipcInvoke('/app/getObjectImage', 'foo'),
-      ]);
+      try {
+        this.bucketIcon = await ipcInvoke('/app/getBucketImage');
+      } catch (error) {
+        // Noop
+      }
 
-      this.bucketIcon = res[0];
-      this.folderIcon = res[1];
-      this.defaultIcon = res[2];
+      try {
+        this.folderIcon = await ipcInvoke('/app/getFolderImage');
+      } catch (error) {
+        // Noop
+      }
+
+      try {
+        this.defaultIcon = await ipcInvoke('/app/getObjectImage', 'foo.foo');
+      } catch (error) {
+        // Noop
+      }
     },
 
     async getFileIcons() {


### PR DESCRIPTION
Icon support for win32.

There is no good way to get the native server icon in win32 like we do for darwin. So for now we'll just use the folder icon and come back to this later.
